### PR TITLE
Make com_port use template send/receive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 bin
 OpenBLAS
 old
+perf.data*

--- a/src/detail/communication.hpp
+++ b/src/detail/communication.hpp
@@ -3,109 +3,252 @@
 #include <mpi/mpi.h>
 #include <vector>
 
+class com_request : public std::vector<MPI_Request>
+{
+    // A communicator request, will hold many MPI_Requests when
+    // sending composite types
+    // It's probably(?) ok to pass around MPI_Requests like that
+public:
+    com_request &operator<<(const com_request &rhs)
+    {
+        this->reserve(this->size() + rhs.size());
+        this->insert(this->end(), rhs.begin(), rhs.end());
+        return *this;
+    }
+    com_request(MPI_Request r)
+    {
+        this->push_back(r);
+    }
+};
 
-using com_request = std::vector<MPI_Request>;
-
-class com_port{
+class com_port
+{
     // Interface to send/receive data
-    // NOTE: Currently does not work for sending/receiving multiple
-    // objects simultaneously (one send and one receive at the same
-    // time works).
+    // Contains multi-argument variadic templates with
+    // specializations for intrinsinc types that we use (size_type and vector<double>).
+    // The goal is (1) make it easier to send composite types (structs),
+    // using the syntax "send(destination, a, b, c, ...)", where a,b,c,... can be
+    // any combination of supported types and (2) make it easy to overload
+    // "send(int destination, T)" for custom types.
+    // ((It's overkill for this assignment but I wanted to play around with templates))
 
-    int _rank; // Rank(==id) of proccess where this com_port is created.
-    int _world_size; // Number of processes we can communicate with.
+    // Internal value, needed to send multiple elements of the same type
+    // without mixing them up on the receiving end
+    unsigned int _tag;
+
+    // Rank(==id) of proccess where this com_port is created.
+    unsigned int _rank;
+
+    // Number of processes we can communicate with.
+    unsigned int _world_size;
 
 public:
     // Constructor
-    com_port(int rank, int world_size){ 
-        _rank = rank; 
+    com_port(unsigned int rank, unsigned int world_size)
+    {
+        _tag = 0;
+        _rank = rank;
         _world_size = world_size;
     }
 
     int rank() const { return _rank; }
-    int world_size() const {return _world_size;}
-
-    // Expose sending/receiving interface:
+    int world_size() const { return _world_size; }
 
     // Blocking receive
     template <typename T>
-    void receive(T& obj, int sender_rank);
+    void receive(int source_id, T &t);
+
+    template <typename... P>
+        requires(sizeof...(P) > 1)
+    void receive(int source_id, P &...p)
+    {
+        (receive(source_id, p), ...);
+        std::cout << "PROC\t" << _rank << "\tRECV " << _tag << std::endl;
+        _tag = 0; // reset tag
+    }
 
     // Non-blocking receive
     template <typename T>
-    com_request receive_begin(T& obj, int sender_rank);
+    com_request receive_begin(int source_id, T &);
+
+    template <typename... P>
+        requires(sizeof...(P) > 1)
+    com_request receive_begin(int source_id, P &...p)
+    {
+        com_request request = (receive_begin(source_id, p) << ...);
+        std::cout << "PROC\t" << _rank << "\tISEND\t" << _tag << std::endl;
+        _tag = 0; // reset tag
+        return request;
+    }
 
     // Blocking send
     template <typename T>
-    void send(T& obj, int receiver_rank);
+    void send(int source_id, T &);
+
+    template <typename... P>
+        requires(sizeof...(P) > 1)
+    void send(int destination_id, P &...p)
+    {
+        (send(destination_id, p), ...);
+        std::cout << "PROC\t" << _rank << "\tSEND\t" << _tag << std::endl;
+        _tag = 0; // reset tag
+    }
 
     // Non-blocking send
     template <typename T>
-    com_request send_begin(T& obj, int receiver_rank);
+    com_request send_begin(int source_id, T &);
+
+    template <typename... P>
+        requires(sizeof...(P) > 1)
+    com_request send_begin(int destination_id, P &...p)
+    {
+        com_request request = (send_begin(destination_id, p) << ...);
+        std::cout << "PROC\t" << _rank << "\tIRECV\t" << _tag << std::endl;
+        _tag = 0;
+        return request;
+    }
+
+    // com_request send_begin(int destination_id, size_t &k);
+    // com_request send_begin(int destination_id, std::vector<double> &k);
 
     // Waits for a non-blocking communication to complete
-    void wait(com_request request){
-        for(auto& request_elem : request){
+    void wait(com_request request)
+    {
+        for (auto &request_elem : request)
+        {
             MPI_Wait(&request_elem, nullptr);
         }
     };
-
 };
 
+// Implement send/receive for the intrinsic types that we will use
+// If we had compile-time access to MPI_INT, MPI_DOUBlE etc, this
+// could have been much more elegant
 
+////////////////
+/// RECEIVE ///
+//////////////
 
-// Implementation for int:
-
-template<>
-inline void com_port::send(int& k, int receiver_rank){
-    MPI_Send(&k, 1, MPI_INT, receiver_rank, 0, MPI_COMM_WORLD);
+template <>
+inline void com_port::receive(int source_id, int &k)
+{
+    MPI_Recv(&k, 1, MPI_INT, source_id, _tag++, MPI_COMM_WORLD, nullptr);
 }
 
-template<>
-inline com_request com_port::send_begin(int& k, int receiver_rank){
+template <>
+inline void com_port::receive(int source_id, size_t &k)
+{
+    MPI_Recv(&k, 1, MPI_UNSIGNED_LONG, source_id, _tag++, MPI_COMM_WORLD, nullptr);
+}
+
+template <>
+inline void com_port::receive(int source_id, std::vector<double> &v)
+{
+    MPI_Recv(v.data(), v.size(), MPI_DOUBLE, source_id, _tag++, MPI_COMM_WORLD, nullptr);
+}
+
+template <>
+inline void com_port::receive(int source_id, std::vector<size_t> &v)
+{
+    MPI_Recv(v.data(), v.size(), MPI_UNSIGNED_LONG, source_id, _tag++, MPI_COMM_WORLD, nullptr);
+}
+
+/////////////////////////////
+/// NON-BLOCKING RECEIVE ///
+///////////////////////////
+
+template <>
+inline com_request com_port::receive_begin(int source_id, int &k)
+{
     MPI_Request request;
-    MPI_Isend(&k, 1, MPI_INT, receiver_rank, 0, MPI_COMM_WORLD, &request);
+    MPI_Irecv(&k, 1, MPI_INT, source_id, _tag++, MPI_COMM_WORLD, &request);
     return com_request{request};
 }
 
-template<>
-inline void com_port::receive(int& k, int sender_rank){
-    MPI_Recv(&k, 1, MPI_INT, sender_rank, 0, MPI_COMM_WORLD, nullptr);
-}
-
-template<>
-inline com_request com_port::receive_begin(int& k, int sender_rank){
+template <>
+inline com_request com_port::receive_begin(int source_id, size_t &k)
+{
     MPI_Request request;
-    MPI_Irecv(&k, 1, MPI_INT, sender_rank, 0, MPI_COMM_WORLD, &request);
+    MPI_Irecv(&k, 1, MPI_UNSIGNED_LONG, source_id, _tag++, MPI_COMM_WORLD, &request);
     return com_request{request};
 }
 
-
-
-// Implementation for std::vector<double>
-
-template<>
-inline void com_port::send(std::vector<double>& vec, int receiver_rank){
-    MPI_Send(vec.data(), vec.size(), MPI_DOUBLE, receiver_rank, 0, MPI_COMM_WORLD);
+template <>
+inline com_request com_port::receive_begin(int source_id, std::vector<double> &v)
+{
+    MPI_Request request;
+    MPI_Irecv(v.data(), v.size(), MPI_DOUBLE, source_id, _tag++, MPI_COMM_WORLD, &request);
+    return com_request{request};
 }
 
-template<>
-inline com_request com_port::send_begin(std::vector<double>& vec, int receiver_rank){
-    com_request requests(1);
-    MPI_Isend(vec.data(), vec.size(), MPI_DOUBLE, receiver_rank, 0, MPI_COMM_WORLD, &requests[0]);
-    return requests;
+template <>
+inline com_request com_port::receive_begin(int source_id, std::vector<size_t> &v)
+{
+    MPI_Request request;
+    MPI_Irecv(v.data(), v.size(), MPI_UNSIGNED_LONG, source_id, _tag++, MPI_COMM_WORLD, &request);
+    return com_request{request};
 }
 
-template<>
-inline void com_port::receive(std::vector<double>& vec, int sender_rank){
-    // Assume that c.data memory has already been initialized
-    MPI_Recv(vec.data(), vec.size(), MPI_DOUBLE, sender_rank, 0, MPI_COMM_WORLD, nullptr);
+/////////////
+/// SEND ///
+///////////
+
+template <>
+inline void com_port::send(int destination_id, int &k)
+{
+    MPI_Send(&k, 1, MPI_INT, destination_id, _tag++, MPI_COMM_WORLD);
 }
 
-template<>
-inline com_request com_port::receive_begin(std::vector<double>& vec, int sender_rank){
-    // Assume that c.data memory has already been initialized
-    com_request requests(1);
-    MPI_Irecv(vec.data(), vec.size(), MPI_DOUBLE, sender_rank, 0, MPI_COMM_WORLD, &requests[0]);
-    return com_request{requests};
+template <>
+inline void com_port::send(int destination_id, size_t &k)
+{
+    MPI_Send(&k, 1, MPI_UNSIGNED_LONG, destination_id, _tag++, MPI_COMM_WORLD);
+}
+
+template <>
+inline void com_port::send(int destination_id, std::vector<double> &v)
+{
+    MPI_Send(v.data(), v.size(), MPI_DOUBLE, destination_id, _tag++, MPI_COMM_WORLD);
+}
+
+template <>
+inline void com_port::send(int destination_id, std::vector<size_t> &v)
+{
+    MPI_Send(v.data(), v.size(), MPI_UNSIGNED_LONG, destination_id, _tag++, MPI_COMM_WORLD);
+}
+
+//////////////////////////
+/// NON_BLOCKING SEND ///
+////////////////////////
+
+template <>
+inline com_request com_port::send_begin(int destination_id, int &k)
+{
+    MPI_Request request;
+    MPI_Isend(&k, 1, MPI_INT, destination_id, _tag++, MPI_COMM_WORLD, &request);
+    return com_request{request};
+}
+
+template <>
+inline com_request com_port::send_begin(int destination_id, size_t &k)
+{
+    MPI_Request request;
+    MPI_Isend(&k, 1, MPI_UNSIGNED_LONG, destination_id, _tag++, MPI_COMM_WORLD, &request);
+    return com_request{request};
+}
+
+template <>
+inline com_request com_port::send_begin(int destination_id, std::vector<double> &v)
+{
+    MPI_Request request;
+    MPI_Isend(v.data(), v.size(), MPI_DOUBLE, destination_id, _tag++, MPI_COMM_WORLD, &request);
+    return com_request{request};
+}
+
+template <>
+inline com_request com_port::send_begin(int destination_id, std::vector<size_t> &v)
+{
+    MPI_Request request;
+    MPI_Isend(v.data(), v.size(), MPI_UNSIGNED_LONG, destination_id, _tag++, MPI_COMM_WORLD, &request);
+    return com_request{request};
 }

--- a/src/detail/communication.hpp
+++ b/src/detail/communication.hpp
@@ -56,7 +56,7 @@ public:
 
     // Blocking receive
     template <typename T>
-    void receive(int source_id, T &t);
+    void receive(int source_id, T &t) = delete;
 
     template <typename... P>
         requires(sizeof...(P) > 1)
@@ -69,7 +69,7 @@ public:
 
     // Non-blocking receive
     template <typename T>
-    com_request receive_begin(int source_id, T &);
+    com_request receive_begin(int source_id, T &) = delete;
 
     template <typename... P>
         requires(sizeof...(P) > 1)
@@ -83,7 +83,7 @@ public:
 
     // Blocking send
     template <typename T>
-    void send(int source_id, T &);
+    void send(int source_id, T &) = delete;
 
     template <typename... P>
         requires(sizeof...(P) > 1)
@@ -96,7 +96,7 @@ public:
 
     // Non-blocking send
     template <typename T>
-    com_request send_begin(int source_id, T &);
+    com_request send_begin(int source_id, T &) = delete;
 
     template <typename... P>
         requires(sizeof...(P) > 1)

--- a/src/detail/knn_structs.hpp
+++ b/src/detail/knn_structs.hpp
@@ -31,6 +31,18 @@ struct CorpusPacket
           y_end_index(y_end_index), Y(std::move(Y)) {}
 };
 
+template <>
+inline com_request com_port::send_begin(int destination_id, CorpusPacket &c)
+{
+    return send_begin(destination_id, c.d, c.n_packet, c.y_start_index, c.y_end_index, c.Y);
+}
+
+template <>
+inline com_request com_port::receive_begin(int source_id, CorpusPacket &c)
+{
+    return receive_begin(source_id, c.d, c.n_packet, c.y_start_index, c.y_end_index, c.Y);
+}
+
 struct QueryPacket
 {
     size_t m_packet;
@@ -58,6 +70,18 @@ struct QueryPacket
         : m_packet(m_packet), d(d), x_start_index(x_start_index),
           x_end_index(x_end_index), X(std::move(X)) {}
 };
+
+template <>
+inline com_request com_port::send_begin(int destination_id, QueryPacket &c)
+{
+    return send_begin(destination_id, c.d, c.m_packet, c.x_start_index, c.x_end_index, c.X);
+}
+
+template <>
+inline com_request com_port::receive_begin(int source_id, QueryPacket &c)
+{
+    return receive_begin(source_id, c.d, c.m_packet, c.x_start_index, c.x_end_index, c.X);
+}
 
 struct ResultPacket
 {
@@ -114,224 +138,14 @@ struct ResultPacket
                  size_t k);
 };
 
-// CorpusPacket send/receive (This is ugly and wrong in so
-// many ways, i know)
-
 template <>
-inline void com_port::send(CorpusPacket &c, int receiver_rank)
+inline void com_port::send(int destination_id, ResultPacket &c)
 {
-    MPI_Send(c.Y.data(), c.n_packet * c.d, MPI_DOUBLE, receiver_rank, 0,
-             MPI_COMM_WORLD);
-    MPI_Send(&c.n_packet, 1, MPI_INT, receiver_rank, 1, MPI_COMM_WORLD);
-    MPI_Send(&c.d, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD);
-    MPI_Send(&c.y_start_index, 1, MPI_INT, receiver_rank, 3, MPI_COMM_WORLD);
-    MPI_Send(&c.y_end_index, 1, MPI_INT, receiver_rank, 4, MPI_COMM_WORLD);
+    send(destination_id, c.k, c.m_packet, c.n_packet, c.ndist, c.nidx, c.x_end_index, c.x_start_index, c.y_end_index, c.y_start_index);
 }
 
 template <>
-inline com_request com_port::send_begin(CorpusPacket &c, int receiver_rank)
+inline void com_port::receive(int destination_id, ResultPacket &c)
 {
-    com_request requests(5);
-    MPI_Isend(c.Y.data(), c.n_packet * c.d, MPI_DOUBLE, receiver_rank, 0,
-              MPI_COMM_WORLD, &requests[0]);
-    MPI_Isend(&c.n_packet, 1, MPI_INT, receiver_rank, 1, MPI_COMM_WORLD,
-              &requests[1]);
-    MPI_Isend(&c.d, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD, &requests[2]);
-    MPI_Isend(&c.y_start_index, 1, MPI_INT, receiver_rank, 3, MPI_COMM_WORLD,
-              &requests[3]);
-    MPI_Isend(&c.y_end_index, 1, MPI_INT, receiver_rank, 4, MPI_COMM_WORLD,
-              &requests[4]);
-
-    return requests;
-}
-
-template <>
-inline void com_port::receive(CorpusPacket &c, int sender_rank)
-{
-    // Assume that c.data memory has already been initialized
-    MPI_Recv(c.Y.data(), c.Y.size(), MPI_DOUBLE, sender_rank, 0, MPI_COMM_WORLD,
-             nullptr);
-    MPI_Recv(&c.n_packet, 1, MPI_INT, sender_rank, 1, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&c.d, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&c.y_start_index, 1, MPI_INT, sender_rank, 3, MPI_COMM_WORLD,
-             nullptr);
-    MPI_Recv(&c.y_end_index, 1, MPI_INT, sender_rank, 4, MPI_COMM_WORLD,
-             nullptr);
-}
-
-template <>
-inline com_request com_port::receive_begin(CorpusPacket &c, int sender_rank)
-{
-    // Assume that c.data memory has already been initialized
-    com_request requests(5);
-    MPI_Irecv(c.Y.data(), c.Y.size(), MPI_DOUBLE, sender_rank, 0,
-              MPI_COMM_WORLD, &requests[0]);
-    MPI_Irecv(&c.n_packet, 1, MPI_INT, sender_rank, 1, MPI_COMM_WORLD,
-              &requests[1]);
-    MPI_Irecv(&c.d, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD, &requests[2]);
-    MPI_Irecv(&c.y_start_index, 1, MPI_INT, sender_rank, 3, MPI_COMM_WORLD,
-              &requests[3]);
-    MPI_Irecv(&c.y_end_index, 1, MPI_INT, sender_rank, 4, MPI_COMM_WORLD,
-              &requests[4]);
-
-    return com_request{requests};
-}
-
-// QueryPacket send/receive (This is ugly and wrong in so
-// many ways, i know)
-
-template <>
-inline void com_port::send(QueryPacket &c, int receiver_rank)
-{
-    MPI_Send(c.X.data(), c.m_packet * c.d, MPI_DOUBLE, receiver_rank, 0,
-             MPI_COMM_WORLD);
-    MPI_Send(&c.m_packet, 1, MPI_INT, receiver_rank, 1, MPI_COMM_WORLD);
-    MPI_Send(&c.d, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD);
-    MPI_Send(&c.x_start_index, 1, MPI_INT, receiver_rank, 3, MPI_COMM_WORLD);
-    MPI_Send(&c.x_end_index, 1, MPI_INT, receiver_rank, 4, MPI_COMM_WORLD);
-}
-
-template <>
-inline com_request com_port::send_begin(QueryPacket &c, int receiver_rank)
-{
-    com_request requests(5);
-    MPI_Isend(c.X.data(), c.m_packet * c.d, MPI_DOUBLE, receiver_rank, 0,
-              MPI_COMM_WORLD, &requests[0]);
-    MPI_Isend(&c.m_packet, 1, MPI_INT, receiver_rank, 1, MPI_COMM_WORLD,
-              &requests[1]);
-    MPI_Isend(&c.d, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD, &requests[2]);
-    MPI_Isend(&c.x_start_index, 1, MPI_INT, receiver_rank, 3, MPI_COMM_WORLD,
-              &requests[3]);
-    MPI_Isend(&c.x_end_index, 1, MPI_INT, receiver_rank, 4, MPI_COMM_WORLD,
-              &requests[4]);
-
-    return requests;
-}
-
-template <>
-inline void com_port::receive(QueryPacket &c, int sender_rank)
-{
-    // Assume that c.data memory has already been initialized
-    MPI_Recv(c.X.data(), c.X.size(), MPI_DOUBLE, sender_rank, 0, MPI_COMM_WORLD,
-             nullptr);
-    MPI_Recv(&c.m_packet, 1, MPI_INT, sender_rank, 1, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&c.d, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&c.x_start_index, 1, MPI_INT, sender_rank, 3, MPI_COMM_WORLD,
-             nullptr);
-    MPI_Recv(&c.x_end_index, 1, MPI_INT, sender_rank, 4, MPI_COMM_WORLD,
-             nullptr);
-}
-
-template <>
-inline com_request com_port::receive_begin(QueryPacket &c, int sender_rank)
-{
-    // Assume that c.data memory has already been initialized
-    com_request requests(5);
-    MPI_Irecv(c.X.data(), c.X.size(), MPI_DOUBLE, sender_rank, 0,
-              MPI_COMM_WORLD, &requests[0]);
-    MPI_Irecv(&c.m_packet, 1, MPI_INT, sender_rank, 1, MPI_COMM_WORLD,
-              &requests[1]);
-    MPI_Irecv(&c.d, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD, &requests[2]);
-    MPI_Irecv(&c.x_start_index, 1, MPI_INT, sender_rank, 3, MPI_COMM_WORLD,
-              &requests[3]);
-    MPI_Irecv(&c.x_end_index, 1, MPI_INT, sender_rank, 4, MPI_COMM_WORLD,
-              &requests[4]);
-
-    return com_request{requests};
-}
-
-// ResultsPacket send/receive (This is ugly and wrong in so
-// many ways, i know)
-
-template <>
-inline void com_port::send(ResultPacket &c, int receiver_rank)
-{
-    MPI_Send(c.nidx.data(), c.k, MPI_INT, receiver_rank, 0, MPI_COMM_WORLD);
-    MPI_Send(c.ndist.data(), c.k, MPI_DOUBLE, receiver_rank, 1, MPI_COMM_WORLD);
-
-    MPI_Send(&c.m_packet, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD);
-    MPI_Send(&c.n_packet, 1, MPI_INT, receiver_rank, 3, MPI_COMM_WORLD);
-
-    MPI_Send(&c.k, 1, MPI_INT, receiver_rank, 4, MPI_COMM_WORLD);
-    MPI_Send(&c.x_start_index, 1, MPI_INT, receiver_rank, 5, MPI_COMM_WORLD);
-    MPI_Send(&c.x_end_index, 1, MPI_INT, receiver_rank, 6, MPI_COMM_WORLD);
-    MPI_Send(&c.y_start_index, 1, MPI_INT, receiver_rank, 7, MPI_COMM_WORLD);
-    MPI_Send(&c.y_end_index, 1, MPI_INT, receiver_rank, 8, MPI_COMM_WORLD);
-}
-
-template <>
-inline com_request com_port::send_begin(ResultPacket &c, int receiver_rank)
-{
-    com_request requests(9);
-    MPI_Isend(c.nidx.data(), c.nidx.size(), MPI_INT, receiver_rank, 0,
-              MPI_COMM_WORLD, &requests[0]);
-    MPI_Isend(c.ndist.data(), c.ndist.size(), MPI_DOUBLE, receiver_rank, 1,
-              MPI_COMM_WORLD, &requests[1]);
-
-    MPI_Isend(&c.m_packet, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD,
-              &requests[2]);
-    MPI_Isend(&c.n_packet, 1, MPI_INT, receiver_rank, 3, MPI_COMM_WORLD,
-              &requests[3]);
-
-    MPI_Isend(&c.k, 1, MPI_INT, receiver_rank, 4, MPI_COMM_WORLD, &requests[4]);
-    MPI_Isend(&c.x_start_index, 1, MPI_INT, receiver_rank, 5, MPI_COMM_WORLD,
-              &requests[5]);
-    MPI_Isend(&c.x_end_index, 1, MPI_INT, receiver_rank, 6, MPI_COMM_WORLD,
-              &requests[6]);
-    MPI_Isend(&c.y_start_index, 1, MPI_INT, receiver_rank, 7, MPI_COMM_WORLD,
-              &requests[7]);
-    MPI_Isend(&c.y_end_index, 1, MPI_INT, receiver_rank, 8, MPI_COMM_WORLD,
-              &requests[8]);
-    return requests;
-}
-
-template <>
-inline void com_port::receive(ResultPacket &c, int sender_rank)
-{
-    // Assume that c.data memory has already been initialized
-    MPI_Recv(c.nidx.data(), c.nidx.size(), MPI_INT, sender_rank, 0,
-             MPI_COMM_WORLD, nullptr);
-    MPI_Recv(c.ndist.data(), c.ndist.size(), MPI_DOUBLE, sender_rank, 1,
-             MPI_COMM_WORLD, nullptr);
-
-    MPI_Recv(&c.m_packet, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&c.n_packet, 1, MPI_INT, sender_rank, 3, MPI_COMM_WORLD, nullptr);
-
-    MPI_Recv(&c.k, 1, MPI_INT, sender_rank, 4, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&c.x_start_index, 1, MPI_INT, sender_rank, 5, MPI_COMM_WORLD,
-             nullptr);
-    MPI_Recv(&c.x_end_index, 1, MPI_INT, sender_rank, 6, MPI_COMM_WORLD,
-             nullptr);
-    MPI_Recv(&c.y_start_index, 1, MPI_INT, sender_rank, 7, MPI_COMM_WORLD,
-             nullptr);
-    MPI_Recv(&c.y_end_index, 1, MPI_INT, sender_rank, 8, MPI_COMM_WORLD,
-             nullptr);
-}
-
-template <>
-inline com_request com_port::receive_begin(ResultPacket &c, int sender_rank)
-{
-    // Assume that c.data memory has already been initialized
-    com_request requests(9);
-    MPI_Irecv(c.nidx.data(), c.nidx.size(), MPI_INT, sender_rank, 0,
-              MPI_COMM_WORLD, &requests[0]);
-    MPI_Irecv(c.ndist.data(), c.ndist.size(), MPI_DOUBLE, sender_rank, 1,
-              MPI_COMM_WORLD, &requests[1]);
-
-    MPI_Irecv(&c.m_packet, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD,
-              &requests[2]);
-    MPI_Irecv(&c.n_packet, 1, MPI_INT, sender_rank, 3, MPI_COMM_WORLD,
-              &requests[3]);
-
-    MPI_Irecv(&c.k, 1, MPI_INT, sender_rank, 4, MPI_COMM_WORLD, &requests[4]);
-    MPI_Irecv(&c.x_start_index, 1, MPI_INT, sender_rank, 5, MPI_COMM_WORLD,
-              &requests[5]);
-    MPI_Irecv(&c.x_end_index, 1, MPI_INT, sender_rank, 6, MPI_COMM_WORLD,
-              &requests[6]);
-    MPI_Irecv(&c.y_start_index, 1, MPI_INT, sender_rank, 7, MPI_COMM_WORLD,
-              &requests[7]);
-    MPI_Irecv(&c.y_end_index, 1, MPI_INT, sender_rank, 8, MPI_COMM_WORLD,
-              &requests[8]);
-
-    return com_request{requests};
+    receive(destination_id, c.k, c.m_packet, c.n_packet, c.ndist, c.nidx, c.x_end_index, c.x_start_index, c.y_end_index, c.y_start_index);
 }

--- a/src/detail/knn_structs.hpp
+++ b/src/detail/knn_structs.hpp
@@ -32,13 +32,13 @@ struct CorpusPacket
 };
 
 template <>
-inline com_request com_port::send_begin(int destination_id, CorpusPacket &c)
+inline com_request com_port::_impl_send_begin(int destination_id, CorpusPacket &c)
 {
     return send_begin(destination_id, c.d, c.n_packet, c.y_start_index, c.y_end_index, c.Y);
 }
 
 template <>
-inline com_request com_port::receive_begin(int source_id, CorpusPacket &c)
+inline com_request com_port::_impl_receive_begin(int source_id, CorpusPacket &c)
 {
     return receive_begin(source_id, c.d, c.n_packet, c.y_start_index, c.y_end_index, c.Y);
 }
@@ -72,13 +72,13 @@ struct QueryPacket
 };
 
 template <>
-inline com_request com_port::send_begin(int destination_id, QueryPacket &c)
+inline com_request com_port::_impl_send_begin(int destination_id, QueryPacket &c)
 {
     return send_begin(destination_id, c.d, c.m_packet, c.x_start_index, c.x_end_index, c.X);
 }
 
 template <>
-inline com_request com_port::receive_begin(int source_id, QueryPacket &c)
+inline com_request com_port::_impl_receive_begin(int source_id, QueryPacket &c)
 {
     return receive_begin(source_id, c.d, c.m_packet, c.x_start_index, c.x_end_index, c.X);
 }
@@ -139,13 +139,13 @@ struct ResultPacket
 };
 
 template <>
-inline void com_port::send(int destination_id, ResultPacket &c)
+inline void com_port::_impl_send(int destination_id, ResultPacket &c)
 {
     send(destination_id, c.k, c.m_packet, c.n_packet, c.ndist, c.nidx, c.x_end_index, c.x_start_index, c.y_end_index, c.y_start_index);
 }
 
 template <>
-inline void com_port::receive(int destination_id, ResultPacket &c)
+inline void com_port::_impl_receive(int destination_id, ResultPacket &c)
 {
     receive(destination_id, c.k, c.m_packet, c.n_packet, c.ndist, c.nidx, c.x_end_index, c.x_start_index, c.y_end_index, c.y_start_index);
 }

--- a/src/detail/worker.hpp
+++ b/src/detail/worker.hpp
@@ -17,12 +17,12 @@ struct initial_work_data
 };
 
 template <>
-void com_port::send(int destination_id, initial_work_data &d)
+void com_port::_impl_send(int destination_id, initial_work_data &d)
 {
     send(destination_id, d.n, d.d, d.k);
 }
 template <>
-void com_port::receive(int source_id, initial_work_data &d)
+void com_port::_impl_receive(int source_id, initial_work_data &d)
 {
     receive(source_id, d.n, d.d, d.k);
 }

--- a/src/detail/worker.hpp
+++ b/src/detail/worker.hpp
@@ -11,46 +11,20 @@ struct initial_work_data
 {
     // Must be passed to every worker proccess, stores
     // data that is not known at compile time
-    int n; // number of d-dimensional points in each packet
-    int d; // dimensionality of point-space
-    int k; // number of nearest neighbours that should be found
+    size_t n; // number of d-dimensional points in each packet
+    size_t d; // dimensionality of point-space
+    size_t k; // number of nearest neighbours that should be found
 };
 
-// Could be made to take advantage of existing "com_port::send(int&, int)"
 template <>
-void com_port::send(initial_work_data &d, int receiver_rank)
+void com_port::send(int destination_id, initial_work_data &d)
 {
-    MPI_Send(&d.n, 1, MPI_INT, receiver_rank, 0, MPI_COMM_WORLD);
-    MPI_Send(&d.d, 1, MPI_INT, receiver_rank, 1, MPI_COMM_WORLD);
-    MPI_Send(&d.k, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD);
+    send(destination_id, d.n, d.d, d.k);
 }
-
 template <>
-com_request com_port::send_begin(initial_work_data &d, int receiver_rank)
+void com_port::receive(int source_id, initial_work_data &d)
 {
-    com_request requests(3);
-    MPI_Isend(&d.n, 1, MPI_INT, receiver_rank, 0, MPI_COMM_WORLD, &requests[0]);
-    MPI_Isend(&d.d, 1, MPI_INT, receiver_rank, 1, MPI_COMM_WORLD, &requests[1]);
-    MPI_Isend(&d.k, 1, MPI_INT, receiver_rank, 2, MPI_COMM_WORLD, &requests[2]);
-    return requests;
-}
-
-template <>
-void com_port::receive(initial_work_data &d, int sender_rank)
-{
-    MPI_Recv(&d.n, 1, MPI_INT, sender_rank, 0, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&d.d, 1, MPI_INT, sender_rank, 1, MPI_COMM_WORLD, nullptr);
-    MPI_Recv(&d.k, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD, nullptr);
-}
-
-template <>
-com_request com_port::receive_begin(initial_work_data &d, int sender_rank)
-{
-    com_request requests(3);
-    MPI_Irecv(&d.n, 1, MPI_INT, sender_rank, 0, MPI_COMM_WORLD, &requests[0]);
-    MPI_Irecv(&d.d, 1, MPI_INT, sender_rank, 1, MPI_COMM_WORLD, &requests[1]);
-    MPI_Irecv(&d.k, 1, MPI_INT, sender_rank, 2, MPI_COMM_WORLD, &requests[2]);
-    return com_request{requests};
+    receive(source_id, d.n, d.d, d.k);
 }
 
 class worker
@@ -82,7 +56,7 @@ public:
         // The master mpi process is responsible for transfering initial
         // data to all workers. Then, the workers will exchange data in a
         // cyclical pattern, until all workers have processed all data.
-        com.receive(init_data, MASTER_RANK);
+        com.receive(MASTER_RANK, init_data);
         init();
     }
 
@@ -161,8 +135,8 @@ public:
 
             // Start sending the part we just proccessed
             // Start receiving the part we will proccess later
-            com_request send_req = com.send_begin(corpus, next_rank);
-            com_request recv_req = com.receive_begin(receiving_corpus, prev_rank);
+            com_request send_req = com.send_begin(next_rank, corpus);
+            com_request recv_req = com.receive_begin(prev_rank, receiving_corpus);
             // com.send(corpus, next_rank);
             // com.receive(receiving_corpus, prev_rank);
 
@@ -191,8 +165,13 @@ public:
         results = combineKnnResultsSameX(batch_result, results);
         deb_v();
 
+        MPI_Barrier(MPI_COMM_WORLD);
         // Work finished, send results to master process
         if (com.rank() != MASTER_RANK)
-            com.send(results, MASTER_RANK);
+        {
+            com.send(MASTER_RANK, results);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 };

--- a/src/mpi.cpp
+++ b/src/mpi.cpp
@@ -14,13 +14,15 @@ void master_main(mpi_process &process)
 
     com_port com(process.world_rank, process.world_size);
 
-    int part_size = 20000;
+    size_t part_size = 10; // # points per packet
+    size_t d = 2;          // 2 dimensional points
+    size_t k = 3;          // # nearest neighbours
 
     // Send initial data to all workers
-    initial_work_data init_data{part_size, 2, 3};
+    initial_work_data init_data{part_size, d, k};
     for (int i = 1; i < process.world_size; i++)
     {
-        com.send(init_data, i);
+        com.send(i, init_data);
     }
     // Initialize local worker
     worker w(process.world_rank, process.world_size, init_data);
@@ -32,8 +34,9 @@ void master_main(mpi_process &process)
     diffProcRes.push_back(w.results);
     for (int i = 1; i < process.world_size; i++)
     {
-        ResultPacket result(init_data.k);
-        com.receive(result, i);
+        std::cout << process.world_rank << "GotResult" << std::endl;
+        ResultPacket result(part_size * k);
+        com.receive(i, result);
         diffProcRes.push_back(result);
     }
 
@@ -48,7 +51,6 @@ void master_main(mpi_process &process)
 
 void slave_main(mpi_process &process)
 {
-
     worker w(process.world_rank, process.world_size);
     w.work();
 }


### PR DESCRIPTION
Use templates for send/send_begin/receive/receive_begin functions, which allows for 2 things:

1. Call send/receive with variable # of arguments: 

If all implementations of **send(dest_id, x)** exist for x being any of the types [A, B, C], then **send(dest_id, obj1, obj2, ..., objN)** is also valid syntax for obj  being any of the implemented types [A,B,C].  
**send(dest_id, obj1, obj2, ..., objN)** will call **send(dest_id, obj1)**, then **send(dest_id, obj2)** ... then **send(dest_id, objN)**   
The same syntax also works for non-blocking **com_request send_begin(dest_id, obj1, obj2, ... objN)**, which will return a composite **com_request** object, which can be use to check if all **obj1, obj2, .... objN** have completed communication.

2. Easier implementation of send/receive for new types :

This is an example of implementing send/receive for new types:
```c++
struct my_type{
// assuming that send/receive have been implemented for these types!
  int x;
  double y;
  std::vector<double> vec;
};

template<>
inline void com_port::_impl_send(int dest_id, my_type& o){
  send(dest_id, o.x, o.y, o.vec);
}

template<>
inline void com_port::_impl_send_begin(int dest_id, my_type& o){
  return send_begin(dest_id, o.x, o.y, o.vec);
}

template<>
inline void com_port::_impl_receive(int source_id, my_type& o){
  receive(source_id, o.x, o.y, o.vec);
}

template<>
inline void com_port::_impl_receive_begin(int source_id, my_type& o){
  receive(source_id, o.x, o.y, o.vec);
}
```

The newly defined my_type can now be sent/received, and also used in variadic template expressions:
```c++
com_port com(...);

my_type obj1{42, 1.111, {1,2,3,4}};
my_type obj2{0, 1, {0,1,0,1}};
int x = 5;
other_type other(...);

// blocking send
com.send( 1, obj1, obj2, x, other);

//non-blocking send
com_request req = com.send_begin(1, obj1, obj2, x, other);
// ... do other work
com.wait(req);
```


